### PR TITLE
Rename Repbase direcotry to avoid confusing caused

### DIFF
--- a/code/GenerateAnnotatedLibrary.java
+++ b/code/GenerateAnnotatedLibrary.java
@@ -20,7 +20,7 @@ GenerateAnnotatedLibrary
 		SSR.txt (list of sequences identified as SSRs, and the SSR they matched)
 		protein.txt (list of the sequences identified as proteins and the protein they matched)
 		//LA4v2-satellite.fa (a satellite sequence for which no consensus sequence was found)
-		/home/a1635743/RepBase_lib/* (RepBase libraries to base 
+		/home/a1635743/RepBase_lib/*.rep.ref (RepBase libraries to base 
 			classification on)
 	Outputs: wantedCSHeaders.txt (for checking individual sequence headers)
 		R4_Library.fasta (The annotated library)

--- a/code/GenerateAnnotatedLibrary.java~
+++ b/code/GenerateAnnotatedLibrary.java~
@@ -20,7 +20,7 @@ GenerateAnnotatedLibrary
 		SSR.txt (list of sequences identified as SSRs, and the SSR they matched)
 		protein.txt (list of the sequences identified as proteins and the protein they matched)
 		//LA4v2-satellite.fa (a satellite sequence for which no consensus sequence was found)
-		/home/a1635743/RepBase_lib/* (RepBase libraries to base 
+		/home/a1635743/RepBase20.04.fasta/*rep.ref (RepBase libraries to base 
 			classification on)
 	Outputs: wantedCSHeaders.txt (for checking individual sequence headers)
 		R4_Library.fasta (The annotated library)
@@ -435,7 +435,7 @@ public class GenerateAnnotatedLibrary {
 			}
 
 		private String getLibraryDirectory () {
-			return "/home/a1635743/RepBase_lib";
+			return "/home/a1635743/RepBase20.04.fasta";
 			}
 		}
 


### PR DESCRIPTION
@dadelson @kortschak Revised Joy's code in GenerateAnnotatedLibrary.java, the original code point to RepBase libraries caused confusing.